### PR TITLE
[Feature] Multi dub w/ season constraints

### DIFF
--- a/@types/crunchyTypes.d.ts
+++ b/@types/crunchyTypes.d.ts
@@ -44,7 +44,8 @@ export type CrunchyMultiDownload = {
   dubLang: string[],
   all?: boolean,
   but?: boolean,
-  e?: string
+  e?: string,
+  s?: string
 }
 
 export type CrunchyMuxOptions = {

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2183,6 +2183,7 @@ export default class Crunchy implements ServiceClass {
     for(const season of Object.keys(result) as unknown as number[]) {
       for (const key of Object.keys(result[season])) {
         const s = result[season][key];
+        if (data.s && s.id !== data.s) continue;
         (await this.getSeasonDataById(s))?.data?.forEach(episode => {
           //TODO: Make sure the below code is ok
           //Prepare the episode array
@@ -2229,19 +2230,11 @@ export default class Crunchy implements ServiceClass {
     for (const key of Object.keys(episodes)) {
       const item = episodes[key];
       const isSpecial = !item.items[0].episode.match(/^\d+$/);
-      const episodeNumber = isSpecial ? item.items[0].episode : item.items[0].episode_number;
-      const seasonIdentifier = `S${item.items[0].season_id}`;
-
-      if (!data.s) {
-        episodes[`${isSpecial ? 'S' : 'E'}${itemIndexes[isSpecial ? 'sp' : 'no']}`] = item;
-        if (isSpecial)
-          itemIndexes.sp++;
-        else
-          itemIndexes.no++;
-      } else {
-        episodes[`${isSpecial ? 'S' : 'E'}${episodeNumber}|${seasonIdentifier}`] = item;
-      }
-
+      episodes[`${isSpecial ? 'S' : 'E'}${itemIndexes[isSpecial ? 'sp' : 'no']}`] = item;
+      if (isSpecial)
+        itemIndexes.sp++;
+      else
+        itemIndexes.no++;
       delete episodes[key];
     }
 
@@ -2322,7 +2315,7 @@ export default class Crunchy implements ServiceClass {
           item.series_title = 'NO_TITLE';
         }
 
-        const epNum = key.startsWith('E') ? key.slice(1).split('|')[0] : key.split('|')[0];
+        const epNum = key.startsWith('E') ? key.slice(1) : key;
         // set data
         const images = (item.images.thumbnail ?? [[ { source: '/notFound.png' } ]])[0];
         const epMeta: CrunchyEpMeta = {

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2279,7 +2279,7 @@ export default class Crunchy implements ServiceClass {
     console.info('');
     console.info('-'.repeat(30));
     console.info('');
-    const selected = this.itemSelectMultiDub(episodes, data.dubLang, data.but, data.all, data.e, data.s);
+    const selected = this.itemSelectMultiDub(episodes, data.dubLang, data.but, data.all, data.e);
     for (const key of Object.keys(selected)) {
       const item = selected[key];
       console.info(`[S${item.season}E${item.episodeNumber}] - ${item.episodeTitle} [${
@@ -2294,7 +2294,7 @@ export default class Crunchy implements ServiceClass {
   public itemSelectMultiDub (eps: Record<string, {
     items: CrunchyEpisode[],
     langs: langsData.LanguageItem[]
-  }>, dubLang: string[], but?: boolean, all?: boolean, e?: string, s?: string ) {
+  }>, dubLang: string[], but?: boolean, all?: boolean, e?: string, ) {
     const doEpsFilter = parseSelect(e as string);
 
     const ret: Record<string, CrunchyEpMeta> = {};

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2166,7 +2166,7 @@ export default class Crunchy implements ServiceClass {
       merger.cleanUp();
   }
 
-  public async listSeriesID(id: string, data: CrunchyMultiDownload): Promise<{ list: Episode[], data: Record<string, {
+  public async listSeriesID(id: string, data: CrunchyMultiDownload | undefined = undefined): Promise<{ list: Episode[], data: Record<string, {
     items: CrunchyEpisode[];
     langs: langsData.LanguageItem[];
   }>}> {
@@ -2183,7 +2183,7 @@ export default class Crunchy implements ServiceClass {
     for(const season of Object.keys(result) as unknown as number[]) {
       for (const key of Object.keys(result[season])) {
         const s = result[season][key];
-        if (data.s && s.id !== data.s) continue;
+        if (data?.s && s.id !== data.s) continue;
         (await this.getSeasonDataById(s))?.data?.forEach(episode => {
           //TODO: Make sure the below code is ok
           //Prepare the episode array

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2302,7 +2302,7 @@ export default class Crunchy implements ServiceClass {
     for (const key of Object.keys(eps)) {
       const itemE = eps[key];
       itemE.items.forEach((item, index) => {
-        if (!dubLang.includes(itemE.langs[index]?.code) || (s && item.season_id !== s))
+        if (!dubLang.includes(itemE.langs[index]?.code))
           return;
         item.hide_season_title = true;
         if(item.season_title == '' && item.series_title != ''){

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2166,7 +2166,7 @@ export default class Crunchy implements ServiceClass {
       merger.cleanUp();
   }
 
-  public async listSeriesID(id: string, data: CrunchyMultiDownload | undefined = undefined): Promise<{ list: Episode[], data: Record<string, {
+  public async listSeriesID(id: string, data?: CrunchyMultiDownload): Promise<{ list: Episode[], data: Record<string, {
     items: CrunchyEpisode[];
     langs: langsData.LanguageItem[];
   }>}> {


### PR DESCRIPTION
I created this because there are times where i want to get multiple dubs within a series but i cant do that with `-s` and `--srz` uses indexes rather than episode numbers for ordering. With this change the following output will be generated when using both `-s` and `--srz`:

```txt
[E1|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Failed... Hero [Japanese, English, Portuguese, Spanish]
[E2|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Black Spider of Disaster [Japanese, English, Portuguese, Spanish]
[E3|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Human Shock [Japanese, English, Portuguese, Spanish]
[E4|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Too Late [Japanese, English, Portuguese, Spanish]
[E5|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - The Greedy Wagon's Journey [Japanese, English, Portuguese, Spanish]
[E6|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - The Melancholy of Handsome Middle-Aged Men [Japanese, English, Portuguese, Spanish]
[E7|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Wondrous Medicine Production [Japanese, English, Portuguese, Spanish]
[E8|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Demiplane Ranking [Japanese, English, Portuguese, Spanish]
[E9|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Eat or Be Eaten [Japanese, Portuguese, Spanish, English]
[E10|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Hidden Ogre Village [Japanese, Portuguese, Spanish, English]
[E11|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Goodbye [Japanese, Portuguese, Spanish, English]
[E12|SGY2PCV21D] TSUKIMICHI -Moonlit Fantasy- - Season 1 - Guided by the Moon... [Japanese, Portuguese, Spanish, English]
[E1|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - What? Moon over the Ruined Castle? [☆ Japanese, ☆ English, ☆ Portuguese, ☆ Spanish]
[E2|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - The Heroes Are a Couple of Beauties [☆ Japanese, ☆ English, ☆ Spanish, ☆ Portuguese]
[E3|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - Stellar Wars [☆ Japanese, ☆ English, ☆ Portuguese, ☆ Spanish]
[E4|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - Why Am I a Teacher?! [☆ Japanese, ☆ English, ☆ Portuguese, ☆ Spanish]
[E5|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - The Lesson Will Now Begin [☆ Japanese, ☆ Portuguese, ☆ Spanish, ☆ English]
[E6|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - Becoming a Three-Star Chef [☆ Japanese, ☆ Spanish, ☆ Portuguese, ☆ English]
[E7|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - New Member Audition [☆ Japanese, ☆ English, ☆ Portuguese, ☆ Spanish]
[E8|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - The Notorious Beautiful Sisters [☆ Japanese, ☆ English, ☆ Portuguese, ☆ Spanish]
[E9|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - The Perverted Dragon [☆ Japanese, ☆ English]
[E10|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - Watch As I Improve the World [☆ Japanese]
[E11|SG69PC2JJ4] TSUKIMICHI -Moonlit Fantasy- Season 2 - Season 2 - Summer of Growth and New Skills [☆ Japanese]
```
With this, it sorts by season_id and episode (using season numbers is convoluted with cr's api)

if you exclude `-s` it falls back to the original format of using indexes (so it'll be number 1-23...etc) so overall this will retain the same functionality, but with the added effect that using `-s` will constrain it to the season and allow `-e` to use the episode number of that season.