### PR TITLE
Fixes/enchancements for vtt2ass with new Hidive Q styles

### DIFF
--- a/hidive.ts
+++ b/hidive.ts
@@ -1424,7 +1424,7 @@ export default class Hidive implements ServiceClass {
             if (getVttContent.ok && getVttContent.res) {
               console.info(`Subtitle Downloaded: ${sub.url}`);
               //vttConvert(getVttContent.res.body, false, subLang.name, fontSize);
-              const sBody = vtt2ass(undefined, chosenFontSize, getVttContent.res.body, '', subsMargin, options.fontName);
+              const sBody = vtt2ass(undefined, chosenFontSize, getVttContent.res.body, '', subsMargin, options.fontName, options.combineLines);
               sxData.title = `${subLang.language} / ${sxData.title}`;
               sxData.fonts = fontsData.assFonts(sBody) as Font[];
               fs.writeFileSync(sxData.path, sBody);
@@ -1678,7 +1678,7 @@ export default class Hidive implements ServiceClass {
             if (getCssContent.ok && getVttContent.ok && getCssContent.res && getVttContent.res) {
               console.info(`Subtitle Downloaded: ${await this.genSubsUrl('vtt', subsXUrl)}`);
               //vttConvert(getVttContent.res.body, false, subLang.name, fontSize);
-              const sBody = vtt2ass(undefined, chosenFontSize, getVttContent.res.body, getCssContent.res.body, subsMargin, options.fontName);
+              const sBody = vtt2ass(undefined, chosenFontSize, getVttContent.res.body, getCssContent.res.body, subsMargin, options.fontName, options.combineLines);
               sxData.title = `${subLang.language} / ${sxData.title}`;
               sxData.fonts = fontsData.assFonts(sBody) as Font[];
               fs.writeFileSync(sxData.path, sBody);

--- a/modules/module.app-args.ts
+++ b/modules/module.app-args.ts
@@ -48,6 +48,7 @@ let argvC: {
   dubLang: string[]; 
   all: boolean; 
   fontSize: number; 
+  combineLines: boolean;
   allDubs: boolean; 
   timeout: number; 
   waittime: number;

--- a/modules/module.args.ts
+++ b/modules/module.args.ts
@@ -392,6 +392,15 @@ const args: TAppArg<boolean|number|string|unknown[]>[] = [
     usage: '${fontSize}'
   },
   {
+    name: 'combineLines',
+    describe: 'Merge adjacent lines with same style and text',
+    docDescribe: 'If selected, will prevent a line from shifting downwards',
+    group: 'dl',
+    service: ['hidive'],
+    type: 'boolean',
+    usage: ''
+  },
+  {
     name: 'allDubs',
     describe: 'If selected, all available dubs will get downloaded',
     docDescribe: true,


### PR DESCRIPTION
Addresses https://github.com/anidl/multi-downloader-nx/issues/608. 
- That is, properly reverse simultaneous lines. As a side effect, all lines with a \pos tag will be put at the bottom of the script which lines up better with the behavior before the new Q styles. The implementation in V4.6.0 has some issues with lines being ordered weirdly and newlines being assigned to the wrong events.

---

Additional enhancements:
- Lines with the same data that are adjacent become joined into one event
```
Dialogue: 0,0:06:10.92,0:06:11.71,Q0,,0,0,0,,I'm telling you though, there really is-
Dialogue: 0,0:06:11.71,0:06:13.08,Q0,,0,0,0,,I'm telling you though, there really is-
Dialogue: 0,0:06:11.71,0:06:13.08,Q2,,0,0,0,,I told her we'd talk, but...
Dialogue: 0,0:06:13.08,0:06:14.42,Q2,,0,0,0,,I told her we'd talk, but...
```
Becomes
```
Dialogue: 0,0:06:10.92,0:06:13.08,Q0,,0,0,0,,I'm telling you though, there really is-
Dialogue: 0,0:06:11.71,0:06:14.42,Q2,,0,0,0,,I told her we'd talk, but...
```
This does mean that it will look different from what it looks like on Hidive but it should be more readable. For example in an event like what was shown above:
```
Line 1 -> nothing
Line 2 -> line 1
Line 3 -> line 2
```
Becomes
```
Line 1 -> Line 1
Line 2 -> Line 2
Line 3 -> Empty space
```

This is done in `line 367` if you want to link it up to an option or turn it off.

---

- Lines without a \pos tag get layer 1 so that they can display over potential captions if needed. Otherwise the previous behavior was that captions would obscure the dialogue.

This is done in `line 273`, you can change it to ` Dialogue: 0,${line.start},${line.end},${line.style},,0,0,0,,${line.text}`);` to make it remain on layer 0.