### PR TITLE
[HiDive] Remove unreleased episodes from list

### DIFF
--- a/hidive.ts
+++ b/hidive.ts
@@ -370,15 +370,14 @@ export default class Hidive implements ServiceClass {
       }
       for (const episode of season.value.episodes) {
         const datePattern = /\d{1,2}\/\d{1,2}\/\d{2,4} \d{1,2}:\d{2} UTC/;
-        if (datePattern.test(episode.title) && episode.duration === 10) {
-          continue;
-        }
         if (episode.title.includes(' - ')) {
           episode.episodeInformation.episodeNumber = parseFloat(episode.title.split(' - ')[0].replace('E', ''));
           episode.title = episode.title.split(' - ')[1];
         }
         //S${episode.episodeInformation.seasonNumber}E${episode.episodeInformation.episodeNumber} - 
-        episodes.push(episode);
+        if (!datePattern.test(episode.title) && !episode.duration === 10) {
+          episodes.push(episode);
+        }
         console.info(`    [E.${episode.id}] ${episode.title}`);
       }
     }
@@ -402,15 +401,14 @@ export default class Hidive implements ServiceClass {
     const episodes: Episode[] = [];
     for (const episode of season.value.episodes) {
       const datePattern = /\d{1,2}\/\d{1,2}\/\d{2,4} \d{1,2}:\d{2} UTC/;
-      if (datePattern.test(episode.title) && episode.duration === 10) {
-        continue;
-      }
       if (episode.title.includes(' - ')) {
         episode.episodeInformation.episodeNumber = parseFloat(episode.title.split(' - ')[0].replace('E', ''));
         episode.title = episode.title.split(' - ')[1];
       }
       //S${episode.episodeInformation.seasonNumber}E${episode.episodeInformation.episodeNumber} - 
-      episodes.push(episode);
+      if (!datePattern.test(episode.title) && !episode.duration === 10) {
+        episodes.push(episode);
+      }
       console.info(`    [E.${episode.id}] ${episode.title}`);
     }
     const series: NewHidiveSeriesExtra = {...season.value.series, season: season.value};

--- a/hidive.ts
+++ b/hidive.ts
@@ -375,7 +375,7 @@ export default class Hidive implements ServiceClass {
           episode.title = episode.title.split(' - ')[1];
         }
         //S${episode.episodeInformation.seasonNumber}E${episode.episodeInformation.episodeNumber} - 
-        if (!datePattern.test(episode.title) && !episode.duration === 10) {
+        if (!datePattern.test(episode.title) && episode.duration !== 10) {
           episodes.push(episode);
         }
         console.info(`    [E.${episode.id}] ${episode.title}`);
@@ -406,7 +406,7 @@ export default class Hidive implements ServiceClass {
         episode.title = episode.title.split(' - ')[1];
       }
       //S${episode.episodeInformation.seasonNumber}E${episode.episodeInformation.episodeNumber} - 
-      if (!datePattern.test(episode.title) && !episode.duration === 10) {
+      if (!datePattern.test(episode.title) && episode.duration !== 10) {
         episodes.push(episode);
       }
       console.info(`    [E.${episode.id}] ${episode.title}`);

--- a/hidive.ts
+++ b/hidive.ts
@@ -369,6 +369,10 @@ export default class Hidive implements ServiceClass {
         season.value.paging.moreDataAvailable = seasonPage.value.paging.moreDataAvailable;
       }
       for (const episode of season.value.episodes) {
+        const datePattern = /\d{1,2}\/\d{1,2}\/\d{2,4} \d{1,2}:\d{2} UTC/;
+        if (datePattern.test(episode.title)) {
+          continue;
+        }
         if (episode.title.includes(' - ')) {
           episode.episodeInformation.episodeNumber = parseFloat(episode.title.split(' - ')[0].replace('E', ''));
           episode.title = episode.title.split(' - ')[1];
@@ -397,6 +401,10 @@ export default class Hidive implements ServiceClass {
     }
     const episodes: Episode[] = [];
     for (const episode of season.value.episodes) {
+      const datePattern = /\d{1,2}\/\d{1,2}\/\d{2,4} \d{1,2}:\d{2} UTC/;
+      if (datePattern.test(episode.title)) {
+        continue;
+      }
       if (episode.title.includes(' - ')) {
         episode.episodeInformation.episodeNumber = parseFloat(episode.title.split(' - ')[0].replace('E', ''));
         episode.title = episode.title.split(' - ')[1];

--- a/hidive.ts
+++ b/hidive.ts
@@ -370,7 +370,7 @@ export default class Hidive implements ServiceClass {
       }
       for (const episode of season.value.episodes) {
         const datePattern = /\d{1,2}\/\d{1,2}\/\d{2,4} \d{1,2}:\d{2} UTC/;
-        if (datePattern.test(episode.title)) {
+        if (datePattern.test(episode.title) && episode.duration === 10) {
           continue;
         }
         if (episode.title.includes(' - ')) {
@@ -402,7 +402,7 @@ export default class Hidive implements ServiceClass {
     const episodes: Episode[] = [];
     for (const episode of season.value.episodes) {
       const datePattern = /\d{1,2}\/\d{1,2}\/\d{2,4} \d{1,2}:\d{2} UTC/;
-      if (datePattern.test(episode.title)) {
+      if (datePattern.test(episode.title) && episode.duration === 10) {
         continue;
       }
       if (episode.title.includes(' - ')) {


### PR DESCRIPTION
When doing a range download/single selection of an anime that's currently airing episodes that haven't released will still get downloaded at 0 bytes. This will skip them if they have a date range in them, rather than an appropriate title.