### PR TITLE
Add check for (NC) in parseSelect

### DIFF
--- a/modules/module.parseSelect.ts
+++ b/modules/module.parseSelect.ts
@@ -57,6 +57,9 @@ const parseSelect = (selectString: string, but = false) : {
       } else if (part.match(/[A-Z]{3}\.[0-9]*/)) {
         select.push(part);
         return;
+      } else if (part.match(/E?\d+\s\(NC\)/)) {
+        select.push(part);
+        return;
       }
       const match = part.match(/[A-Za-z]+/);
       if (match && match.length > 0) {
@@ -85,6 +88,9 @@ const parseSelect = (selectString: string, but = false) : {
       return st.some(st => {
         const match = st.match(/[A-Za-z]+/);
         if (st.match(/[0-9A-Z]{9}/)) {
+          const included = select.includes(st);
+          return but ? !included : included;
+        } else if (st.match(/E?\d+\s\(NC\)/)) {
           const included = select.includes(st);
           return but ? !included : included;
         } else if (match && match.length > 0) {


### PR DESCRIPTION
To support selections like `1 (NC)` the parser needed a little change.

This will fix #737 

Working (Tested): 

- [ ] Selection via "List Episodes"
- [x] Selection via Manual Input like `1 (NC)`
- [ ] Range Selection `1 (NC) - 9 (NC)`
- [x] Download

So not everything works as of now but it let's us download those episodes as well