### PR TITLE
fix: subtitle failed to parse URL from undefined

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2447,6 +2447,9 @@ export default class Crunchy implements ServiceClass {
             if (files.some(a => a.type === 'Subtitle' && (a.language.cr_locale == langItem.cr_locale || a.language.locale == langItem.locale) && a.cc === isCC && a.signs === isSigns))
               continue;
             if(options.dlsubs.includes('all') || options.dlsubs.includes(langItem.locale)){
+              if (!subsItem.url) {
+                continue;
+              }
               const subsAssReq = await this.req.getData(subsItem.url, {
                 headers: api.crunchyDefHeader
               });


### PR DESCRIPTION
This pull request fix error below, just skip undefined subtitle and continue
```
[ERROR] TypeError: Failed to parse URL from undefined
[WARN] Failed to download subtitle: tmp.10.und..ass
```