### PR TITLE
order audio tracks based on --dubLang

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2683,6 +2683,11 @@ export default class Crunchy implements ServiceClass {
                 item.langs.push(langsData.languages.find(a => a.cr_locale == version.audio_locale) as langsData.LanguageItem);
               }
             }
+            //Sort audio tracks according to the order of languages passed to the 'dubLang' option
+            const argv = yargs.appArgv(this.cfg.cli);
+            if(!argv.allDubs) {
+              item.langs.sort((a,b) => argv.dubLang.indexOf(a.code) - argv.dubLang.indexOf(b.code));
+            }
           } else {
             //Episode didn't have versions, mark it as such to be logged.
             serieshasversions = false;


### PR DESCRIPTION
This PR updates the crunchyroll audio track selection logic to order audio tracks based on the order of languages passed to the --dubLang option. Previously, audio tracks were not sorted according to user preference. With this change, tracks are prioritized according to the sequence specified in the CLI argument, ensuring the intended language order is respected.