### PR TITLE
[HiDive] Update Undetermined Audio Fix without using generic fallback

### DIFF
--- a/hidive.ts
+++ b/hidive.ts
@@ -743,7 +743,6 @@ export default class Hidive implements ServiceClass {
       replaceWith: chosenVideoSegments.quality.width
     });
 
-    const chosenAudios: typeof audios[0][] = [];
     const audioByLanguage: Record<string,typeof audios[0][]> = {};
     for (const audio of audios) {
       if (!audioByLanguage[audio.language.code]) audioByLanguage[audio.language.code] = [];
@@ -754,7 +753,7 @@ export default class Hidive implements ServiceClass {
 
     // RULE 1: If there is only one audio track and it's 'und', it must be Japanese.
     if (availableLangs.length === 1 && audioByLanguage['und']) {
-        console.info('[INFO] Correcting single \'undetermined\' audio track to Japanese.');
+        console.info('Correcting single \'undetermined\' audio track to Japanese.');
         audioByLanguage['jpn'] = audioByLanguage['und'];
         delete audioByLanguage['und'];
         const japaneseLangItem = langsData.languages.find(lang => lang.code === 'jpn');
@@ -766,7 +765,7 @@ export default class Hidive implements ServiceClass {
     else if (availableLangs.length === 2 && audioByLanguage['und']) {
         // The known track is Japanese, so 'und' must be English.
         if (audioByLanguage['jpn']) {
-            console.info('[INFO] Correcting \'undetermined\' audio track to English.');
+            console.info('Correcting \'undetermined\' audio track to English.');
             audioByLanguage['eng'] = audioByLanguage['und'];
             delete audioByLanguage['und'];
             const englishLangItem = langsData.languages.find(lang => lang.code === 'eng');
@@ -776,7 +775,7 @@ export default class Hidive implements ServiceClass {
         } 
         // The known track is English, so 'und' must be Japanese.
         else if (audioByLanguage['eng']) {
-            console.info('[INFO] Correcting \'undetermined\' audio track to Japanese.');
+            console.info('Correcting \'undetermined\' audio track to Japanese.');
             audioByLanguage['jpn'] = audioByLanguage['und'];
             delete audioByLanguage['und'];
             const japaneseLangItem = langsData.languages.find(lang => lang.code === 'jpn');
@@ -801,9 +800,9 @@ export default class Hidive implements ServiceClass {
     if (chosenAudios.length == 0) {
       const finalAvailableLangs = Object.keys(audioByLanguage);
       if (finalAvailableLangs.length > 0) {
-        console.error(`[ERROR] Requested audio language(s) '${options.dubLang.join(', ')}' not found. Available languages: '${finalAvailableLangs.join(', ')}'. Skipping download.`);
+        console.error(`Requested audio language(s) '${options.dubLang.join(', ')}' not found. Available languages: '${finalAvailableLangs.join(', ')}'. Skipping download.`);
       } else {
-        console.error(`[CRITICAL] No audio tracks available for episode ${selectedEpisode.episodeInformation.episodeNumber}.`);
+        console.error(`No audio tracks available for episode ${selectedEpisode.episodeInformation.episodeNumber}.`);
       }
       return undefined;
     }


### PR DESCRIPTION
This PR restores the original strict audio selection behavior for HiDive, while still fixing the underlying bug that caused crashes on tracks with an und (Undetermined) language tag.

A previous fix (1e45610a) was committed to prevent the downloader from crashing on und tracks. While this prevented crashes, it did so by introduced a generic fallback that would download any available audio if the user's preferred language wasn't found.

This seemed like a regression for users who relied on the original, stricter behavior—for example, I would use the cli to try to grab the dub of an episode coming out that day and would be fine if it failed until the episode actually dropped. But with the fallback introduced to prevent hidive crashing on und audio track edge cases, it would download the japanese audio version, which was a waste of bandwidth and space when I only wanted the english dub. (Also got a little sad when I asked it for English and it said, nope not out yet here is something you never asked for instead. :-P)

This solution offers the best of both worlds by removing the generic fallback and allowing the download to fail since the requested language wasn't there. But it also fixes the crash on the edge cases where a und track was encountered by correcting the metadata before selection, based on these two safe assumptions for HiDive:

1) If there's a single audio track and it's und, it's assumed to be Japanese.

2) If there are two audio tracks and one is und, it infers the other language based on what's present (e.g., if jpn is there, und becomes eng).

I'm not sure if the generic fallback was the right way to go as the und track issue seems to be an edge case that doesn't necessarily warrant a complete and sweeping change of how hidive's service originally functioned.