### PR TITLE
[HD] Add undetermined audio selection and revert fallback

### DIFF
--- a/hidive.ts
+++ b/hidive.ts
@@ -760,19 +760,8 @@ export default class Hidive implements ServiceClass {
       }
     }
     if (chosenAudios.length == 0) {
-      console.warn(`Chosen audio language(s) does not exist for episode ${selectedEpisode.episodeInformation.episodeNumber}, falling back to first available audio`);
-      if (audios.length > 0) {
-        let chosenAudioQuality = options.q === 0 ? audios.length : options.q;
-        if(chosenAudioQuality > audios.length) {
-          chosenAudioQuality = audios.length;
-        }
-        chosenAudioQuality--;
-        chosenAudios.push(audios[chosenAudioQuality]);
-        console.info(`Using audio track: ${audios[chosenAudioQuality].language.code || 'unknown'}`);
-      } else {
-        console.error(`No audio tracks available for episode ${selectedEpisode.episodeInformation.episodeNumber}`);
-        return undefined;
-      }
+      console.error(`Chosen audio language(s) does not exist for episode ${selectedEpisode.episodeInformation.episodeNumber}`);
+      return undefined;
     }
 
     const fileName = parseFileName(options.fileName, variables, options.numbers, options.override).join(path.sep);

--- a/modules/module.langsData.ts
+++ b/modules/module.langsData.ts
@@ -42,6 +42,7 @@ const languages: LanguageItem[] = [
   { cr_locale: 'id-ID', locale: 'id-ID', code: 'ind', name: 'Indonesian', language: 'Bahasa Indonesia' },
   { cr_locale: 'te-IN', locale: 'te-IN', code: 'tel', name: 'Telugu (India)', language: 'తెలుగు' },
   { cr_locale: 'ja-JP', adn_locale: 'ja', ao_locale: 'ja', hd_locale: 'Japanese', locale: 'ja', code: 'jpn', name: 'Japanese' },
+  { locale: 'un', code: 'und', name: 'Undetermined', language: 'Undetermined', new_hd_locale: 'und', cr_locale: 'und', adn_locale: 'und', ao_locale: 'und' },
 ];
 
 // add en language names
@@ -97,7 +98,7 @@ const fixLanguageTag = (tag: string) => {
 // find lang by cr_locale
 const findLang = (cr_locale: string) => {
   const lang = languages.find(l => { return l.cr_locale == cr_locale; });
-  return lang ? lang : { cr_locale: 'und', locale: 'un', code: 'und', name: '', language: '' };
+  return lang ? lang : languages.find(l => l.code === 'und') || { cr_locale: 'und', locale: 'un', code: 'und', name: 'Undetermined', language: 'Undetermined' };
 };
 
 const fixAndFindCrLC = (cr_locale: string) => {


### PR DESCRIPTION
Okay so this one doesn't rely on assumptions but makes undetermined a viable audio selection for cases like Bad Girl Ep 01 which even now seems to be the only hidive video I have come across that has an undetermined audio language. It also reverts the generic fallback that is only present in this service currently as it allows for flag overrides even if an audio is not undetermined. This pull request is far more specific in how it addresses the undetermined audio issue and should be viable for all other services should the issue crop up on another service as well.