### PR TITLE
fix: map ${showTitle} to seriesTitle instead of seasonTitle

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -1792,7 +1792,7 @@ export default class Crunchy implements ServiceClass {
         ['episode', isNaN(parseFloat(medias.episodeNumber)) ? medias.episodeNumber : parseFloat(medias.episodeNumber), false],
         ['service', 'CR', false],
         ['seriesTitle', medias.seriesTitle, true],
-        ['showTitle', medias.seasonTitle, true],
+        ['showTitle', medias.seriesTitle, true],
         ['season', medias.season, false]
       ] as [AvailableFilenameVars, string|number, boolean][]).map((a): Variable => {
         return {
@@ -3065,3 +3065,4 @@ export default class Crunchy implements ServiceClass {
   }
 
 }
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-downloader-nx",
   "short_name": "aniDL",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "Downloader for Crunchyroll, Hidive, AnimeOnegai, and AnimationDigitalNetwork with CLI and GUI",
   "keywords": [
     "download",


### PR DESCRIPTION
Previously ${showTitle} was assigned to the season title, which caused
filenames like "Something Season 4 - S04E..." instead of just the series
name. Now ${showTitle} correctly maps to seriesTitle, while ${season}
still holds the season number. This keeps filenames clean and consistent.