### PR TITLE
Update GET-STARTED.md guide Playready section

### DIFF
--- a/docs/GET-STARTED.md
+++ b/docs/GET-STARTED.md
@@ -155,6 +155,7 @@ Again, the renaming is totally optional. Just make sure both files are in the `w
 If you have a Playready CDM key dump, you just need to make sure:
 1. Its provisioned as a V3 Device by [pyplayready](https://github.com/ready-dl/pyplayready).
 2. Security level is either SL2000 or SL3000
+3. Make sure you are using shaka-packager v2.6.1, as later versions have issues.
 
 After you have confirmed the above, place the file(s) in the `playready` folder, which is in the same directory you opened `aniDL.exe` from.
 


### PR DESCRIPTION
Added part to mention using shaka-packager v2.6.1 is required as newer versions have issues.