### PR TITLE
Add per-episode subtitle listing in console output

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -893,12 +893,14 @@ export default class Crunchy implements ServiceClass {
 		if (item.subtitle_locales) {
 			iMetadata.subtitle_locales = item.subtitle_locales;
 		}
-		if (item.versions && audio_languages.length > 0) {
-			console.info('%s- Versions: %s', ''.padStart(pad + 2, ' '), langsData.parseSubtitlesArray(audio_languages));
-		}
-		if (iMetadata.subtitle_locales && iMetadata.subtitle_locales.length > 0) {
-			console.info('%s- Subtitles: %s', ''.padStart(pad + 2, ' '), langsData.parseSubtitlesArray(iMetadata.subtitle_locales));
-		}
+        // commented out for new per-episode sub listing
+        // instead of the series/season level sub listing
+		// if (item.versions && audio_languages.length > 0) {
+		// 	console.info('%s- Versions: %s', ''.padStart(pad + 2, ' '), langsData.parseSubtitlesArray(audio_languages));
+		// }
+		// if (iMetadata.subtitle_locales && iMetadata.subtitle_locales.length > 0) {
+		// 	console.info('%s- Subtitles: %s', ''.padStart(pad + 2, ' '), langsData.parseSubtitlesArray(iMetadata.subtitle_locales));
+		// }
 		if (item.availability_notes) {
 			console.info('%s- Availability notes: %s', ''.padStart(pad + 2, ' '), item.availability_notes.replace(/\[[^\]]*]?/gm, ''));
 		}
@@ -2920,19 +2922,16 @@ export default class Crunchy implements ServiceClass {
 			normal = Object.entries(episodes).filter((a) => a[0].startsWith('E')),
 			sortedEpisodes = Object.fromEntries([...normal, ...specials]);
 
-		for (const key of Object.keys(sortedEpisodes)) {
-			const item = sortedEpisodes[key];
-			const epNum = key.startsWith('E') ? `E${data?.absolute ? item.items[0].episode_number?.toString() || item.items[0].episode : key.slice(1)}` : key;
-			console.info(
-				`[${data?.absolute ? epNum : key}] [${item.items[0].upload_date ? new Date(item.items[0].upload_date).toISOString().slice(0, 10) : '0000-00-00'}] ${
-					item.items.find((a) => !a.season_title.match(/\(\w+ Dub\)/))?.season_title ?? item.items[0].season_title.replace(/\(\w+ Dub\)/g, '').trimEnd()
-				} - Season ${item.items[0].season_number} - ${item.items[0].title} [${item.items
-					.map((a, index) => {
-						return `${a.is_premium_only ? '☆ ' : ''}${item.langs[index]?.name ?? 'Unknown'}`;
-					})
-					.join(', ')}]`
-			);
-		}
+        for (const key of Object.keys(sortedEpisodes)) {
+            const item = sortedEpisodes[key];
+            const epNum = key.startsWith('E') ? (`E${data?.absolute ? (item.items[0].episode_number?.toString() || item.items[0].episode) : key.slice(1)}`) : key;
+            console.info(`[${data?.absolute ? epNum : key}] [${item.items[0].upload_date ? new Date(item.items[0].upload_date).toISOString().slice(0, 10) : '0000-00-00'}] ${
+                item.items.find(a => !a.season_title.match(/\(\w+ Dub\)/))?.season_title ?? item.items[0].season_title.replace(/\(\w+ Dub\)/g, '').trimEnd()
+            } - Season ${item.items[0].season_number} - ${item.items[0].title}
+            \r\t- Dubs: ${item.items.map((a, index) => {return `${a.is_premium_only ? '☆ ' : ''}${item.langs?.[index]?.name ?? 'Unknown'}`;}).join(', ')}
+            \r\t- Subs: ${[...new Set(item.items.flatMap(a => a.subtitle_locales ?? 'None'))].join(', ')}`
+            );
+        }
 
 		if (!serieshasversions) {
 			console.warn("Couldn't find versions on some episodes, fell back to old method.");

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -893,8 +893,8 @@ export default class Crunchy implements ServiceClass {
 		if (item.subtitle_locales) {
 			iMetadata.subtitle_locales = item.subtitle_locales;
 		}
-        // commented out for new per-episode sub listing
-        // instead of the series/season level sub listing
+		// commented out for new per-episode sub listing
+		// instead of the series/season level sub listing
 		// if (item.versions && audio_languages.length > 0) {
 		// 	console.info('%s- Versions: %s', ''.padStart(pad + 2, ' '), langsData.parseSubtitlesArray(audio_languages));
 		// }
@@ -2922,16 +2922,19 @@ export default class Crunchy implements ServiceClass {
 			normal = Object.entries(episodes).filter((a) => a[0].startsWith('E')),
 			sortedEpisodes = Object.fromEntries([...normal, ...specials]);
 
-        for (const key of Object.keys(sortedEpisodes)) {
-            const item = sortedEpisodes[key];
-            const epNum = key.startsWith('E') ? (`E${data?.absolute ? (item.items[0].episode_number?.toString() || item.items[0].episode) : key.slice(1)}`) : key;
-            console.info(`[${data?.absolute ? epNum : key}] [${item.items[0].upload_date ? new Date(item.items[0].upload_date).toISOString().slice(0, 10) : '0000-00-00'}] ${
-                item.items.find(a => !a.season_title.match(/\(\w+ Dub\)/))?.season_title ?? item.items[0].season_title.replace(/\(\w+ Dub\)/g, '').trimEnd()
-            } - Season ${item.items[0].season_number} - ${item.items[0].title}
-            \r\t- Dubs: ${item.items.map((a, index) => {return `${a.is_premium_only ? '☆ ' : ''}${item.langs?.[index]?.name ?? 'Unknown'}`;}).join(', ')}
-            \r\t- Subs: ${[...new Set(item.items.flatMap(a => a.subtitle_locales ?? 'None'))].join(', ')}`
-            );
-        }
+		for (const key of Object.keys(sortedEpisodes)) {
+			const item = sortedEpisodes[key];
+			const epNum = key.startsWith('E') ? `E${data?.absolute ? item.items[0].episode_number?.toString() || item.items[0].episode : key.slice(1)}` : key;
+			console.info(`[${data?.absolute ? epNum : key}] [${item.items[0].upload_date ? new Date(item.items[0].upload_date).toISOString().slice(0, 10) : '0000-00-00'}] ${
+				item.items.find((a) => !a.season_title.match(/\(\w+ Dub\)/))?.season_title ?? item.items[0].season_title.replace(/\(\w+ Dub\)/g, '').trimEnd()
+			} - Season ${item.items[0].season_number} - ${item.items[0].title}
+            \r\t- Dubs: ${item.items
+				.map((a, index) => {
+					return `${a.is_premium_only ? '☆ ' : ''}${item.langs?.[index]?.name ?? 'Unknown'}`;
+				})
+				.join(', ')}
+            \r\t- Subs: ${[...new Set(item.items.flatMap((a) => a.subtitle_locales ?? 'None'))].join(', ')}`);
+		}
 
 		if (!serieshasversions) {
 			console.warn("Couldn't find versions on some episodes, fell back to old method.");


### PR DESCRIPTION
Made the Crunchyroll CLI output go from this:

```
...
[Z:GDKHZEJ0K] Solo Leveling (Seasons: 2, EPs: 26) [SUB, DUB]
  - Subtitles: en, es-419, es-ES, pt-BR, fr, de, ar, it, ru, hi, zh-CN, zh-HK, th-TH, ta-IN, ms-MY, vi-VN, id-ID, te-IN
  [S:GR19CPDWM] Solo Leveling (Season: 1) [SUB, DUB]
    - Versions: en, es-419, es-ES, pt-BR, fr, de, it, hi, ko, ta-IN, te-IN, ja
    - Subtitles: en, es-419, es-ES, pt-BR, fr, de, ar, it, ru, th-TH, ms-MY, vi-VN, id-ID
  [S:GY09CX813] Solo Leveling Season 2 -Arise from the Shadow- (Season: 2) [SIMULCAST, SUB, DUB]
    - Versions: en, es-419, es-ES, pt-BR, fr, de, it, hi, ko, ta-IN, te-IN, ja
    - Subtitles: en, es-419, es-ES, pt-BR, fr, de, ar, it, ru, zh-CN, zh-HK, th-TH, ms-MY, vi-VN, id-ID
[E1] [2024-01-06] Solo Leveling - Season 1 - I'm Used to It [Hindi, Portuguese, Spanish, German, French, Italian, Castilian, Tamil (India), Telugu (India), English, Korean, Japanese]
[E2] [2024-01-13] Solo Leveling - Season 1 - If I Had One More Chance [Portuguese, German, Italian, French, Telugu (India), Tamil (India), Spanish, Hindi, English, Castilian, Korean, Japanese]
...
```

To this:

```
...
[Z:GDKHZEJ0K] Solo Leveling (Seasons: 2, EPs: 26) [SUB, DUB]
  [S:GR19CPDWM] Solo Leveling (Season: 1) [SUB, DUB]
  [S:GY09CX813] Solo Leveling Season 2 -Arise from the Shadow- (Season: 2) [SIMULCAST, SUB, DUB]
USER: Anonymous
[E1] [2024-01-06] Solo Leveling - Season 1 - I'm Used to It
        - Dubs: Hindi, Portuguese, Spanish, German, French, Italian, Castilian, Tamil (India), Telugu (India), English, Korean, Japanese
        - Subs: en-US, es-419, es-ES, fr-FR, pt-BR, ar-SA, it-IT, de-DE, ru-RU, th-TH, ms-MY, id-ID, vi-VN
[E2] [2024-01-13] Solo Leveling - Season 1 - If I Had One More Chance
        - Dubs: Portuguese, German, Italian, French, Telugu (India), Tamil (India), Spanish, Hindi, English, Castilian, Korean, Japanese
        - Subs: en-US, es-419, es-ES, fr-FR, pt-BR, ar-SA, it-IT, de-DE, ru-RU, th-TH, ms-MY, id-ID, vi-VN
...
```
Just has per-episode subtitle listing instead of series/season listing.

Had an issue a few months ago where S01E05 of "lord of mysteries" didn't have any subs at all.
According to the console output (series/season section), the episode was suppose to have the sub, but it didn't.
This PR aims to solve that :)

If no subs exist for the episode (which is rare), it will output `Subs: None`.

Tested with:
```
npx eslint . --quiet

ts-node -T ./index.ts --service "crunchy" --srz "GDKHZEJ0K"
ts-node -T ./index.ts --service "crunchy" --srz "GQWH0M1J3"
ts-node -T ./index.ts --service "crunchy" --srz "G79H23Z93"
ts-node -T ./index.ts --service "crunchy" --srz "G6W4QKX0R"
```
Also tried downloading from each series and everything worked out.
Let me know if you want any changes! :)

Closes #1075
