### PR TITLE
Fix broken show names

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -1777,7 +1777,7 @@ export default class Crunchy implements ServiceClass {
 						['episode', isNaN(parseFloat(medias.episodeNumber)) ? medias.episodeNumber : parseFloat(medias.episodeNumber), false],
 						['service', 'CR', false],
 						['seriesTitle', medias.seriesTitle, true],
-						['showTitle', medias.seriesTitle ?? medias.seasonTitle, true],
+						['showTitle', medias.seasonTitle === "Season 1" || !medias.seasonTitle ? medias.seriesTitle : medias.seasonTitle, true],
 						['season', medias.season, false]
 					] as [AvailableFilenameVars, string | number, boolean][]
 				).map((a): Variable => {
@@ -3303,3 +3303,4 @@ export default class Crunchy implements ServiceClass {
 		return episodeList;
 	}
 }
+


### PR DESCRIPTION
Fix an issue where the show displays the incorrect name by dynamically selecting between seriesTitle and seasonTitle. Uses seriesTitle if seasonTitle is "Season 1" or unavailable; otherwise, uses seasonTitle.