### PR TITLE
Fix Crunchyroll token expiry calculation

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -425,7 +425,7 @@ export default class Crunchy implements ServiceClass {
 		}
 		this.token = await authReq.res.json();
 		this.token.device_id = uuid;
-    this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
+		this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
 		yamlCfg.saveCRToken(this.token);
 		await this.getProfile();
 		console.info('Your Country: %s', this.token.country);
@@ -464,7 +464,7 @@ export default class Crunchy implements ServiceClass {
 		}
 		this.token = await authReq.res.json();
 		this.token.device_id = uuid;
-    this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
+		this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
 		yamlCfg.saveCRToken(this.token);
 	}
 
@@ -535,7 +535,7 @@ export default class Crunchy implements ServiceClass {
 		}
 		this.token = await authReq.res.json();
 		this.token.device_id = uuid;
-    this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
+		this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
 		yamlCfg.saveCRToken(this.token);
 		await this.getProfile(false);
 		await this.getCMStoken(true);
@@ -586,7 +586,7 @@ export default class Crunchy implements ServiceClass {
 			}
 			this.token = await authReq.res.json();
 			this.token.device_id = uuid;
-    this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
+			this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
 			yamlCfg.saveCRToken(this.token);
 		}
 		if (this.token.refresh_token) {


### PR DESCRIPTION
- Fix expires_in calculation by multiplying by 1000 to convert seconds to milliseconds
- This resolves the issue where creation time seemed like it was also being used as expiry time

Date.now() returns the current time as a Unix timestamp in milliseconds so we were adding 300 to the millisecond count, so like a fraction of a second. Meaning almost anything that you do back to back would require a refresh token call when really it doesn't. This was triggering "suspicious activity" emails when the project I am using was making multiple search calls to find series and episode information to grab missing episodes that crunchyroll neglected to add to their calendar but should have been released.