### PR TITLE
[Feat] Create separate config files based on proxy

### DIFF
--- a/adn.ts
+++ b/adn.ts
@@ -66,7 +66,7 @@ export default class AnimationDigitalNetwork implements ServiceClass {
 	public async cli() {
 		console.info(`\n=== Multi Downloader NX ${packageJson.version} ===\n`);
 		const argv = yargs.appArgv(this.cfg.cli);
-        this.token = yamlCfg.loadADNToken(argv.proxy);
+		this.token = yamlCfg.loadADNToken(argv.proxy);
 		if (['fr', 'de'].includes(argv.locale)) this.locale = argv.locale;
 		if (argv.debug) this.debug = true;
 
@@ -201,7 +201,7 @@ export default class AnimationDigitalNetwork implements ServiceClass {
 			return { isOk: false, reason: new Error('Authentication failed') };
 		}
 		this.token = await authReq.res.json();
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveADNToken(this.token, argv.proxy);
 		console.info('Authentication Success');
 		return { isOk: true, value: undefined };
@@ -224,7 +224,7 @@ export default class AnimationDigitalNetwork implements ServiceClass {
 			return { isOk: false, reason: new Error('Token refresh failed') };
 		}
 		this.token = await authReq.res.json();
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveADNToken(this.token, argv.proxy);
 		return { isOk: true, value: undefined };
 	}

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -76,7 +76,7 @@ export default class Crunchy implements ServiceClass {
 	public async cli() {
 		console.info(`\n=== Multi Downloader NX ${packageJson.version} ===\n`);
 		const argv = yargs.appArgv(this.cfg.cli);
-        this.token = yamlCfg.loadCRToken(argv.proxy);
+		this.token = yamlCfg.loadCRToken(argv.proxy);
 		this.locale = argv.locale;
 		if (argv.debug) this.debug = true;
 
@@ -426,7 +426,7 @@ export default class Crunchy implements ServiceClass {
 		this.token = await authReq.res.json();
 		this.token.device_id = uuid;
 		this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveCRToken(this.token, argv.proxy);
 		await this.getProfile();
 		console.info('Your Country: %s', this.token.country);
@@ -467,7 +467,7 @@ export default class Crunchy implements ServiceClass {
 		this.token = await authReq.res.json();
 		this.token.device_id = uuid;
 		this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveCRToken(this.token, argv.proxy);
 	}
 
@@ -539,7 +539,7 @@ export default class Crunchy implements ServiceClass {
 		this.token = await authReq.res.json();
 		this.token.device_id = uuid;
 		this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveCRToken(this.token, argv.proxy);
 		await this.getProfile(false);
 		await this.getCMStoken(true);
@@ -592,7 +592,7 @@ export default class Crunchy implements ServiceClass {
 			this.token = await authReq.res.json();
 			this.token.device_id = uuid;
 			this.token.expires = new Date(Date.now() + this.token.expires_in * 1000);
-            const argv = yargs.appArgv(this.cfg.cli);
+			const argv = yargs.appArgv(this.cfg.cli);
 			yamlCfg.saveCRToken(this.token, argv.proxy);
 		}
 		if (this.token.refresh_token) {

--- a/hidive.ts
+++ b/hidive.ts
@@ -53,7 +53,7 @@ export default class Hidive implements ServiceClass {
 	public async cli() {
 		console.info(`\n=== Multi Downloader NX ${packageJson.version} ===\n`);
 		const argv = yargs.appArgv(this.cfg.cli);
-        this.token = yamlCfg.loadNewHDToken(argv.proxy);
+		this.token = yamlCfg.loadNewHDToken(argv.proxy);
 		if (argv.debug) this.debug = true;
 
 		//below is for quickly testing API calls
@@ -225,7 +225,7 @@ export default class Hidive implements ServiceClass {
 			this.token[token] = tokens[token];
 		}
 		this.token.guest = false;
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveNewHDToken(this.token, argv.proxy);
 		console.info('Auth complete!');
 		return { isOk: true, value: undefined };
@@ -243,7 +243,7 @@ export default class Hidive implements ServiceClass {
 		}
 		//this.token.expires = new Date(Date.now() + 300);
 		this.token.guest = true;
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveNewHDToken(this.token, argv.proxy);
 		return true;
 	}
@@ -267,7 +267,7 @@ export default class Hidive implements ServiceClass {
 			for (const token in tokens) {
 				this.token[token] = tokens[token];
 			}
-            const argv = yargs.appArgv(this.cfg.cli);
+			const argv = yargs.appArgv(this.cfg.cli);
 			yamlCfg.saveNewHDToken(this.token, argv.proxy);
 			return true;
 		}
@@ -283,7 +283,7 @@ export default class Hidive implements ServiceClass {
 		for (const token in tokens) {
 			this.token[token] = tokens[token];
 		}
-        const argv = yargs.appArgv(this.cfg.cli);
+		const argv = yargs.appArgv(this.cfg.cli);
 		yamlCfg.saveNewHDToken(this.token, argv.proxy);
 		return true;
 	}

--- a/modules/module.cfg-loader.ts
+++ b/modules/module.cfg-loader.ts
@@ -38,12 +38,12 @@ const tokenFile = {
 };
 
 const getTokenFile = (service: 'cr' | 'hd' | 'hdNew' | 'adn', proxyUrl?: string): string => {
-    const baseFile = tokenFile[service];
-    if (!proxyUrl) {
-        return baseFile;
-    }
-    const hash = crypto.createHash('md5').update(proxyUrl).digest('hex').substring(0, 8);
-    return `${baseFile}_${hash}`;
+	const baseFile = tokenFile[service];
+	if (!proxyUrl) {
+		return baseFile;
+	}
+	const hash = crypto.createHash('md5').update(proxyUrl).digest('hex').substring(0, 8);
+	return `${baseFile}_${hash}`;
 };
 
 export const ensureConfig = () => {
@@ -210,43 +210,43 @@ const saveCRSession = (data: Record<string, unknown>) => {
 };
 
 const loadCRToken = (proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('cr', proxyUrl);
-    let token = loadYamlCfgFile(tokenFilePath, true);
-    if (typeof token !== 'object' || token === null || Array.isArray(token)) {
-        token = {};
-    }
-    return token;
+	const tokenFilePath = getTokenFile('cr', proxyUrl);
+	let token = loadYamlCfgFile(tokenFilePath, true);
+	if (typeof token !== 'object' || token === null || Array.isArray(token)) {
+		token = {};
+	}
+	return token;
 };
 
 const saveCRToken = (data: Record<string, unknown>, proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('cr', proxyUrl);
-    const cfgFolder = path.dirname(tokenFilePath);
-    try {
-        fs.ensureDirSync(cfgFolder);
-        fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
-    } catch (e) {
-        console.error("Can't save token file to disk!");
-    }
+	const tokenFilePath = getTokenFile('cr', proxyUrl);
+	const cfgFolder = path.dirname(tokenFilePath);
+	try {
+		fs.ensureDirSync(cfgFolder);
+		fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
+	} catch (e) {
+		console.error("Can't save token file to disk!");
+	}
 };
 
 const loadADNToken = (proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('adn', proxyUrl);
-    let token = loadYamlCfgFile(tokenFilePath, true);
-    if (typeof token !== 'object' || token === null || Array.isArray(token)) {
-        token = {};
-    }
-    return token;
+	const tokenFilePath = getTokenFile('adn', proxyUrl);
+	let token = loadYamlCfgFile(tokenFilePath, true);
+	if (typeof token !== 'object' || token === null || Array.isArray(token)) {
+		token = {};
+	}
+	return token;
 };
 
 const saveADNToken = (data: Record<string, unknown>, proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('adn', proxyUrl);
-    const cfgFolder = path.dirname(tokenFilePath);
-    try {
-        fs.ensureDirSync(cfgFolder);
-        fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
-    } catch (e) {
-        console.error("Can't save token file to disk!");
-    }
+	const tokenFilePath = getTokenFile('adn', proxyUrl);
+	const cfgFolder = path.dirname(tokenFilePath);
+	try {
+		fs.ensureDirSync(cfgFolder);
+		fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
+	} catch (e) {
+		console.error("Can't save token file to disk!");
+	}
 };
 
 const loadHDSession = () => {
@@ -273,23 +273,23 @@ const saveHDSession = (data: Record<string, unknown>) => {
 };
 
 const loadHDToken = (proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('hd', proxyUrl);
-    let token = loadYamlCfgFile(tokenFilePath, true);
-    if (typeof token !== 'object' || token === null || Array.isArray(token)) {
-        token = {};
-    }
-    return token;
+	const tokenFilePath = getTokenFile('hd', proxyUrl);
+	let token = loadYamlCfgFile(tokenFilePath, true);
+	if (typeof token !== 'object' || token === null || Array.isArray(token)) {
+		token = {};
+	}
+	return token;
 };
 
 const saveHDToken = (data: Record<string, unknown>, proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('hd', proxyUrl);
-    const cfgFolder = path.dirname(tokenFilePath);
-    try {
-        fs.ensureDirSync(cfgFolder);
-        fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
-    } catch (e) {
-        console.error("Can't save token file to disk!");
-    }
+	const tokenFilePath = getTokenFile('hd', proxyUrl);
+	const cfgFolder = path.dirname(tokenFilePath);
+	try {
+		fs.ensureDirSync(cfgFolder);
+		fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
+	} catch (e) {
+		console.error("Can't save token file to disk!");
+	}
 };
 
 const saveHDProfile = (data: Record<string, unknown>) => {
@@ -324,23 +324,23 @@ const loadHDProfile = () => {
 };
 
 const loadNewHDToken = (proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('hdNew', proxyUrl);
-    let token = loadYamlCfgFile(tokenFilePath, true);
-    if (typeof token !== 'object' || token === null || Array.isArray(token)) {
-        token = {};
-    }
-    return token;
+	const tokenFilePath = getTokenFile('hdNew', proxyUrl);
+	let token = loadYamlCfgFile(tokenFilePath, true);
+	if (typeof token !== 'object' || token === null || Array.isArray(token)) {
+		token = {};
+	}
+	return token;
 };
 
 const saveNewHDToken = (data: Record<string, unknown>, proxyUrl?: string) => {
-    const tokenFilePath = getTokenFile('hdNew', proxyUrl);
-    const cfgFolder = path.dirname(tokenFilePath);
-    try {
-        fs.ensureDirSync(cfgFolder);
-        fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
-    } catch (e) {
-        console.error("Can't save token file to disk!");
-    }
+	const tokenFilePath = getTokenFile('hdNew', proxyUrl);
+	const cfgFolder = path.dirname(tokenFilePath);
+	try {
+		fs.ensureDirSync(cfgFolder);
+		fs.writeFileSync(`${tokenFilePath}.yml`, yaml.stringify(data));
+	} catch (e) {
+		console.error("Can't save token file to disk!");
+	}
 };
 
 const cfgDir = path.join(workingDir, 'config');


### PR DESCRIPTION
This will create yml files based on the proxy url used, if no proxy is used it'll default to the normal name of the yml. This is so that new devices don't have to be created every time you want to alternate. 