### PR TITLE
Update get started guide's Playready section

### DIFF
--- a/docs/GET-STARTED.md
+++ b/docs/GET-STARTED.md
@@ -156,7 +156,7 @@ If you have a Playready CDM key dump, you just need to make sure:
 1. Its provisioned as a V3 Device by [pyplayready](https://github.com/ready-dl/pyplayready).
 2. Security level is either SL2000 or SL3000
 3. Make sure you are using the latest version of shaka-packager from Stratuma, as he has patched it to work with multi-downloader-nx.\
-   You can find his releases [here](https://github.com/stratumadev/shaka-packager/releases)
+   You can find his releases [here](https://github.com/stratumadev/shaka-packager/releases/latest)
 
 After you have confirmed the above, place the file(s) in the `playready` folder, which is in the same directory you opened `aniDL.exe` from.
 


### PR DESCRIPTION
Update the Playready part of the guide to include Stratuma's patched version of shaka-packager and where to download it.