### PR TITLE
Update playready section of get started guide

### DIFF
--- a/docs/GET-STARTED.md
+++ b/docs/GET-STARTED.md
@@ -159,13 +159,9 @@ If you have a Playready CDM key dump, you just need to make sure:
 3. Make sure you are using the latest version of shaka-packager from Stratuma, as he has patched it to work with multi-downloader-nx.\
    You can find his releases [here](https://github.com/stratumadev/shaka-packager/releases/latest)
 
-If you have a `.prd` file, you will have to convert it to blobs, which will be 2 files: a `bgroupcert.dat` and `zgpriv.dat` file.
-
-1. Go to https://emarsden.github.io/pssh-box-wasm/convert/ and at the top, click on the "Playready" tab.
-2. Scroll down to the "PRD to blobs" section and click on "Choose File". Select your `.prd` file.
-3. Click on the "Convert" button.
-
-It will download a `device_blobs.zip` file. Extract that, rename the `zprivsig.dat` file to `zgpriv.dat`, and copy both `bgroupcert.dat` and `zgpriv.dat` to the `playready` folder.
+> [!NOTE]
+> As of version v5.6.5, multi-downloader-nx now needs the CDM blobs in the form of `bgroupcert.dat` and `zgpriv.dat` files instead of the `.prd` device file. \
+> If you have a `.prd` file as your CDM, multi-downloader-nx will convert that to the required blobs on the fly. No action required ;)
 
 ## Installation
 


### PR DESCRIPTION
Updates the get started guide to include new `bgroupcert.dat` and `zgpriv.dat` file requirement and notifies user that if they have a `.prd` CDM, multi-downloader-nx will convert that on the fly.