### PR TITLE
fix(crunchy): use relative episode numbers for filename generation

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -3376,7 +3376,7 @@ export default class Crunchy implements ServiceClass {
 					],
 					seriesTitle: itemE.items.find((a) => !a.series_title.match(/\(\w+ Dub\)/))?.series_title ?? itemE.items[0].series_title.replace(/\(\w+ Dub\)/g, '').trimEnd(),
 					seasonTitle: itemE.items.find((a) => !a.season_title.match(/\(\w+ Dub\)/))?.season_title ?? itemE.items[0].season_title.replace(/\(\w+ Dub\)/g, '').trimEnd(),
-					episodeNumber: item.episode,
+					episodeNumber: epNum,
 					episodeTitle: item.title,
 					seasonID: item.season_id,
 					season: item.season_number,
@@ -3575,3 +3575,4 @@ export default class Crunchy implements ServiceClass {
 		return episodeList;
 	}
 }
+


### PR DESCRIPTION
### PR Description
When fetching a specific season of a show that uses continuous/absolute numbering on Crunchyroll's backend (such as *Jujutsu Kaisen*), the `aniDL` CLI correctly calculates and displays the relative episode numbers (E1, E2, E3...) in the terminal.

However, when the download is initiated, the `{episode}` variable in the filename template pulls directly from `item.episode` (the raw API absolute number). This causes a mismatch where the user selects episode 9 from the CLI list, but the resulting file is saved as episode 56, breaking local media library management (like Plex or Jellyfin).

**The Solution**
In the `itemSelectMultiDub` function, the `episodeNumber` property mapped into the `epMeta` payload was hardcoded to `item.episode`.

This PR updates that mapping to use the pre-calculated `epNum` variable instead. Since `epNum` already handles the `--absolute` flag logic right above it, this ensures the filename strictly respects the user's configuration and matches the terminal output.

**Example / Before & After**
Testing with Jujutsu Kaisen Season 3:
`aniDL --service crunchy -srz GRDV0019R -s GS00365546JAJP --episode 09`

Output:
* **Before this PR:** The resulting file is named `JUJUTSU KAISEN - S03E56 [1080p].mkv`
* **After this PR:** The resulting file is named `JUJUTSU KAISEN - S03E09 [1080p].mkv`

**Checklist:**

* [x] Tested the change locally.
* [x] Verified that the `--absolute` flag still functions correctly if a user *wants* the continuous numbering.