### PR TITLE
fix: use proxy when get encrypt keys from `hidive` to bypass region lock

### DIFF
--- a/hidive.ts
+++ b/hidive.ts
@@ -907,17 +907,27 @@ export default class Hidive implements ServiceClass {
 		console.info('Stream URL:', chosenVideoSegments.segments[0].map.uri.split('/init.mp4')[0]);
 
 		if ((chosenAudios[0].pssh_wvd && cdm === 'widevine') || (chosenVideoSegments.pssh_wvd && cdm === 'widevine')) {
-			encryptionKeys = await getKeysWVD(chosenVideoSegments.pssh_wvd, 'https://shield-drm.imggaming.com/api/v2/license', {
-				Authorization: `Bearer ${selectedEpisode.jwtToken}`,
-				'X-Drm-Info': 'eyJzeXN0ZW0iOiJjb20ud2lkZXZpbmUuYWxwaGEifQ=='
-			}, true);
+			encryptionKeys = await getKeysWVD(
+				chosenVideoSegments.pssh_wvd,
+				'https://shield-drm.imggaming.com/api/v2/license',
+				{
+					Authorization: `Bearer ${selectedEpisode.jwtToken}`,
+					'X-Drm-Info': 'eyJzeXN0ZW0iOiJjb20ud2lkZXZpbmUuYWxwaGEifQ=='
+				},
+				true
+			);
 		}
 
 		if ((chosenAudios[0].pssh_prd && cdm === 'playready') || (chosenVideoSegments.pssh_prd && cdm === 'playready')) {
-			encryptionKeys = await getKeysPRD(chosenVideoSegments.pssh_prd, 'https://shield-drm.imggaming.com/api/v2/license', {
-				Authorization: `Bearer ${selectedEpisode.jwtToken}`,
-				'X-Drm-Info': 'eyJzeXN0ZW0iOiJjb20ubWljcm9zb2Z0LnBsYXlyZWFkeSJ9'
-			}, true);
+			encryptionKeys = await getKeysPRD(
+				chosenVideoSegments.pssh_prd,
+				'https://shield-drm.imggaming.com/api/v2/license',
+				{
+					Authorization: `Bearer ${selectedEpisode.jwtToken}`,
+					'X-Drm-Info': 'eyJzeXN0ZW0iOiJjb20ubWljcm9zb2Z0LnBsYXlyZWFkeSJ9'
+				},
+				true
+			);
 		}
 
 		if (!options.novids) {

--- a/hidive.ts
+++ b/hidive.ts
@@ -910,14 +910,14 @@ export default class Hidive implements ServiceClass {
 			encryptionKeys = await getKeysWVD(chosenVideoSegments.pssh_wvd, 'https://shield-drm.imggaming.com/api/v2/license', {
 				Authorization: `Bearer ${selectedEpisode.jwtToken}`,
 				'X-Drm-Info': 'eyJzeXN0ZW0iOiJjb20ud2lkZXZpbmUuYWxwaGEifQ=='
-			});
+			}, true);
 		}
 
 		if ((chosenAudios[0].pssh_prd && cdm === 'playready') || (chosenVideoSegments.pssh_prd && cdm === 'playready')) {
 			encryptionKeys = await getKeysPRD(chosenVideoSegments.pssh_prd, 'https://shield-drm.imggaming.com/api/v2/license', {
 				Authorization: `Bearer ${selectedEpisode.jwtToken}`,
 				'X-Drm-Info': 'eyJzeXN0ZW0iOiJjb20ubWljcm9zb2Z0LnBsYXlyZWFkeSJ9'
-			});
+			}, true);
 		}
 
 		if (!options.novids) {

--- a/modules/cdm.ts
+++ b/modules/cdm.ts
@@ -117,7 +117,7 @@ try {
 	canDecrypt = false;
 }
 
-export async function getKeysWVD(pssh: string | undefined, licenseServer: string, authData: Record<string, string>): Promise<KeyContainer[]> {
+export async function getKeysWVD(pssh: string | undefined, licenseServer: string, authData: Record<string, string>, useProxy: boolean = false): Promise<KeyContainer[]> {
 	if (!pssh || !canDecrypt || !widevine) return [];
 	// pssh found in the mpd manifest
 	const psshBuffer = Buffer.from(pssh, 'base64');
@@ -129,7 +129,8 @@ export async function getKeysWVD(pssh: string | undefined, licenseServer: string
 	const licReq = await req.getData(licenseServer, {
 		method: 'POST',
 		body: session.generateChallenge(),
-		headers: authData
+		headers: authData,
+		useProxy
 	});
 
 	if (!licReq.ok || !licReq.res) {
@@ -147,7 +148,7 @@ export async function getKeysWVD(pssh: string | undefined, licenseServer: string
 	}
 }
 
-export async function getKeysPRD(pssh: string | undefined, licenseServer: string, authData: Record<string, string>): Promise<KeyContainer[]> {
+export async function getKeysPRD(pssh: string | undefined, licenseServer: string, authData: Record<string, string>, useProxy: boolean = false): Promise<KeyContainer[]> {
 	if (!pssh || !canDecrypt || !playready) return [];
 
 	// Generate Playready challenge
@@ -157,7 +158,8 @@ export async function getKeysPRD(pssh: string | undefined, licenseServer: string
 	const licReq = await req.getData(licenseServer, {
 		method: 'POST',
 		body: session,
-		headers: authData
+		headers: authData,
+		useProxy
 	});
 
 	if (!licReq.ok || !licReq.res) {


### PR DESCRIPTION
Only hidive, The license server is blocking some regions. 
So, if the proxy parameter setting, it will be bypass the region lock.

this PR adds a `useProxy` parameter in cdm's `getKeysWVD()` and `getKeysPRD()`. this functions will not required the useProxy parameter.
This parameter has applied in `hidive.ts`