### PR TITLE
fix(crunchy,hidive): changed the way multiple keys are sent to shaka

### DIFF
--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2394,8 +2394,8 @@ export default class Crunchy implements ServiceClass {
 								let commandAudio = commandBaseAudio + `"${tempTsFile}.audio.enc.m4s" "${tempTsFile}.audio.m4s"`;
 
 								if (this.cfg.bin.shaka) {
-									commandBaseVideo = ` --enable_raw_key_decryption ${encryptionKeysVideo && encryptionKeysVideo.length > 0 ? `--keys "${encryptionKeysVideo.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
-									commandBaseAudio = ` --enable_raw_key_decryption ${encryptionKeysAudio && encryptionKeysAudio.length > 0 ? `--keys "${encryptionKeysAudio.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
+									commandBaseVideo = ` --enable_raw_key_decryption ${encryptionKeysVideo && encryptionKeysVideo.length > 0 ? `--keys "${encryptionKeysVideo.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"` : ''}`;
+									commandBaseAudio = ` --enable_raw_key_decryption ${encryptionKeysAudio && encryptionKeysAudio.length > 0 ? `--keys "${encryptionKeysAudio.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"` : ''}`;
 									commandVideo = `input="${tempTsFile}.video.enc.m4s",stream=video,output="${tempTsFile}.video.m4s"` + commandBaseVideo;
 									commandAudio = `input="${tempTsFile}.audio.enc.m4s",stream=audio,output="${tempTsFile}.audio.m4s"` + commandBaseAudio;
 								}

--- a/crunchy.ts
+++ b/crunchy.ts
@@ -2394,8 +2394,8 @@ export default class Crunchy implements ServiceClass {
 								let commandAudio = commandBaseAudio + `"${tempTsFile}.audio.enc.m4s" "${tempTsFile}.audio.m4s"`;
 
 								if (this.cfg.bin.shaka) {
-									commandBaseVideo = ` --enable_raw_key_decryption ${encryptionKeysVideo?.map((kb) => '--keys key_id=' + kb.kid + ':key=' + kb.key).join(' ')}`;
-									commandBaseAudio = ` --enable_raw_key_decryption ${encryptionKeysAudio?.map((kb) => '--keys key_id=' + kb.kid + ':key=' + kb.key).join(' ')}`;
+									commandBaseVideo = ` --enable_raw_key_decryption ${encryptionKeysVideo && encryptionKeysVideo.length > 0 ? `--keys "${encryptionKeysVideo.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
+									commandBaseAudio = ` --enable_raw_key_decryption ${encryptionKeysAudio && encryptionKeysAudio.length > 0 ? `--keys "${encryptionKeysAudio.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
 									commandVideo = `input="${tempTsFile}.video.enc.m4s",stream=video,output="${tempTsFile}.video.m4s"` + commandBaseVideo;
 									commandAudio = `input="${tempTsFile}.audio.enc.m4s",stream=audio,output="${tempTsFile}.audio.m4s"` + commandBaseAudio;
 								}

--- a/hidive.ts
+++ b/hidive.ts
@@ -971,7 +971,7 @@ export default class Hidive implements ServiceClass {
 						let commandVideo = commandBase + `"${tempTsFile}.video.enc.m4s" "${tempTsFile}.video.m4s"`;
 
 						if (this.cfg.bin.shaka) {
-							commandBase = ` --enable_raw_key_decryption ${encryptionKeys.map((kb) => '--keys key_id=' + kb.kid + ':key=' + kb.key).join(' ')}`;
+							commandBase = ` --enable_raw_key_decryption ${encryptionKeys && encryptionKeys.length > 0 ? `--keys "${encryptionKeys.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
 							commandVideo = `input="${tempTsFile}.video.enc.m4s",stream=video,output="${tempTsFile}.video.m4s"` + commandBase;
 						}
 
@@ -1066,7 +1066,7 @@ export default class Hidive implements ServiceClass {
 						let commandAudio = commandBase + `"${tempTsFile}.audio.enc.m4s" "${tempTsFile}.audio.m4s"`;
 
 						if (this.cfg.bin.shaka) {
-							commandBase = ` --enable_raw_key_decryption ${encryptionKeys.map((kb) => '--keys key_id=' + kb.kid + ':key=' + kb.key).join(' ')}`;
+							commandBase = ` --enable_raw_key_decryption ${encryptionKeys && encryptionKeys.length > 0 ? `--keys "${encryptionKeys.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
 							commandAudio = `input="${tempTsFile}.audio.enc.m4s",stream=audio,output="${tempTsFile}.audio.m4s"` + commandBase;
 						}
 

--- a/hidive.ts
+++ b/hidive.ts
@@ -971,7 +971,7 @@ export default class Hidive implements ServiceClass {
 						let commandVideo = commandBase + `"${tempTsFile}.video.enc.m4s" "${tempTsFile}.video.m4s"`;
 
 						if (this.cfg.bin.shaka) {
-							commandBase = ` --enable_raw_key_decryption ${encryptionKeys && encryptionKeys.length > 0 ? `--keys "${encryptionKeys.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
+							commandBase = ` --enable_raw_key_decryption ${encryptionKeys && encryptionKeys.length > 0 ? `--keys "${encryptionKeys.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"` : ''}`;
 							commandVideo = `input="${tempTsFile}.video.enc.m4s",stream=video,output="${tempTsFile}.video.m4s"` + commandBase;
 						}
 
@@ -1066,7 +1066,7 @@ export default class Hidive implements ServiceClass {
 						let commandAudio = commandBase + `"${tempTsFile}.audio.enc.m4s" "${tempTsFile}.audio.m4s"`;
 
 						if (this.cfg.bin.shaka) {
-							commandBase = ` --enable_raw_key_decryption ${encryptionKeys && encryptionKeys.length > 0 ? `--keys "${encryptionKeys.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"`:''}`;
+							commandBase = ` --enable_raw_key_decryption ${encryptionKeys && encryptionKeys.length > 0 ? `--keys "${encryptionKeys.map((kb, i) => `label=KEY${i + 1}:key_id=${kb.kid}:key=${kb.key}`).join(',')}"` : ''}`;
 							commandAudio = `input="${tempTsFile}.audio.enc.m4s",stream=audio,output="${tempTsFile}.audio.m4s"` + commandBase;
 						}
 


### PR DESCRIPTION
Changes the flags sent to shaka-packager so that it only sends one --keys flag with many different labels instead of many separate --keys flags.

Tested with both 4 keys and 1 key for crunchy.ts. Sending only one key with the "label=KEY1:" part added did not seem to cause a regression.

Did not test hidive.ts.

Closes #1292